### PR TITLE
Feature/improve page performance

### DIFF
--- a/app/[lang]/[[...slugs]]/page.jsx
+++ b/app/[lang]/[[...slugs]]/page.jsx
@@ -242,7 +242,7 @@ const Page = async ({ params }) => {
   return (
     <>
       {pageSettings?.google_analytics_id &&
-      pageSettings?.google_analytics_id?.length > 0 ? (
+        pageSettings?.google_analytics_id?.length > 0 ? (
         <GoogleAnalytics gaId={pageSettings.google_analytics_id} />
       ) : null}
       <Header lang={params.lang} />
@@ -344,10 +344,10 @@ export async function generateMetadata({ params }) {
       images:
         seoData?._social_image_url !== ''
           ? [
-              {
-                url: `${process.env.NEXT_PUBLIC_CMS_URL}${seoData?._social_image_url}`,
-              },
-            ]
+            {
+              url: `${process.env.NEXT_PUBLIC_CMS_URL}${seoData?._social_image_url}`,
+            },
+          ]
           : [],
     },
     twitter: {
@@ -356,8 +356,8 @@ export async function generateMetadata({ params }) {
       images:
         seoData?._social_image_url !== ''
           ? [
-              `${process.env.NEXT_PUBLIC_CMS_URL}${seoData?._social_image_url}`,
-            ]
+            `${process.env.NEXT_PUBLIC_CMS_URL}${seoData?._social_image_url}`,
+          ]
           : [],
     },
   };

--- a/app/[lang]/[[...slugs]]/page.jsx
+++ b/app/[lang]/[[...slugs]]/page.jsx
@@ -1,6 +1,6 @@
 import {
+  resolveUri,
   getPageListMinimal,
-  getFrontpageId,
   getPage,
   getPageAcf,
 } from '@/utilities/pages';
@@ -35,41 +35,55 @@ import { GoogleAnalytics } from '@next/third-parties/google';
 import PartnersTemplate from '@/components/templates/PartnersTemplate';
 import BlogTemplate from '@/components/templates/BlogTemplate';
 import { getAllPosts } from '@/utilities/posts';
+import { createLocalLink } from '@/utilities/links';
+
+function buildBaseLink(lang, baseSlugs) {
+  const path = baseSlugs.length ? `/${lang}/${baseSlugs.join('/')}/` : `/${lang}`;
+  return createLocalLink(path);
+}
+
+function getUrlPageSlug(page, langPrefix = /^(de\/|en\/|ed\/)/) {
+  const url = new URL(page.link);
+  return url
+    .toString()
+    .substring(url.origin.length)
+    .replace(/^\/|\/$/g, '')
+    .replace(langPrefix, '');
+}
 
 const Page = async ({ params }) => {
   const pageSettings = await getPageSettings(params.lang);
-  const pages = await getPageListMinimal(params.lang);
+  const slugs = params.slugs ?? [];
+  const uri = slugs.join('/');
+  const resolved = await resolveUri(uri, params.lang);
 
-  // find page by slugs
-  let pageSlugs = [...(params.slugs ?? [])];
-  let pageSlug = '';
-  let subSlugs = [];
-  let pageObj;
-  if (pageSlugs.length > 0) {
-    while (pageSlugs.length > 0) {
-      pageObj = pages.find((page) => {
-        const url = new URL(page.link);
-        const urlPageSlug = url
-          .toString()
-          .substring(url.origin.length)
-          .replace(/^\/|\/$/g, '')
-          .replace(/^(de\/|en\/)/, '');
-        return urlPageSlug === pageSlugs?.join('/');
-      });
-      if (pageObj) {
-        pageSlug = pageObj.link;
-        break;
-      }
-      subSlugs = [...subSlugs, pageSlugs.pop()];
-    }
-    if (!pageObj) {
-      const frontpageId = await getFrontpageId(params.lang);
-      pageObj = pages.find((page) => page.id === parseInt(frontpageId));
-      subSlugs = [...(params.slugs ?? [])];
-    }
+  if (!resolved) return notFound();
+
+  const { id, type } = resolved;
+  let pageData;
+  let templateKey;
+  let baseSlugs;
+  let subSlugs;
+  let baseLink;
+
+  if (type === 'page') {
+    pageData = await getPage(params.lang, id);
+    templateKey = pageData.template ?? pageData.meta?.template ?? 'default';
+    if (templateKey && !templateKey.endsWith('.php')) templateKey = `${templateKey}.php`;
+    baseSlugs = slugs;
+    subSlugs = [];
+    baseLink = buildBaseLink(params.lang, baseSlugs);
   } else {
-    const frontpageId = await getFrontpageId(params.lang);
-    pageObj = pages.find((page) => page.id === parseInt(frontpageId));
+    // type === 'story' | 'timeline_event' | 'post': resolve parent page
+    const baseUri = slugs.slice(0, -1).join('/');
+    const parentResolved = await resolveUri(baseUri, params.lang);
+    if (!parentResolved || parentResolved.type !== 'page') return notFound();
+    pageData = await getPage(params.lang, parentResolved.id);
+    templateKey = pageData.template ?? pageData.meta?.template ?? 'default';
+    if (templateKey && !templateKey.endsWith('.php')) templateKey = `${templateKey}.php`;
+    baseSlugs = slugs.slice(0, -1);
+    subSlugs = slugs.length ? [slugs[slugs.length - 1]] : [];
+    baseLink = buildBaseLink(params.lang, baseSlugs);
   }
 
   let stories,
@@ -81,148 +95,148 @@ const Page = async ({ params }) => {
     timeLineEventsDe,
     timeLineEventsEn,
     timelineTopics;
-
-  // get page
   let template;
-  if (pageObj) {
-    const pageData = await getPage(params.lang, pageObj.id);
-    switch (pageObj.template) {
-      case 'page_stories.php':
-        [
-          stories,
-          allMediaDe,
-          allMediaEn,
-          allPersons,
-          topics,
-          timeLineEventsDe,
-          timeLineEventsEn,
-        ] = await Promise.all([
-          getAllStories(params.lang),
-          getAllMedia('de'),
-          getAllMedia('en'),
-          getAllPersons(),
-          fetchAllTopics(params.lang),
-          getTimeline('de', params.lang),
-          getTimeline('us', params.lang),
-        ]);
-        allMedia = [...allMediaDe, ...allMediaEn];
-        template = (
-          <StoriesTemplate
+
+  switch (templateKey) {
+    case 'page_stories.php':
+      [
+        stories,
+        allMediaDe,
+        allMediaEn,
+        allPersons,
+        topics,
+        timeLineEventsDe,
+        timeLineEventsEn,
+      ] = await Promise.all([
+        getAllStories(params.lang),
+        getAllMedia('de'),
+        getAllMedia('en'),
+        getAllPersons(),
+        fetchAllTopics(params.lang),
+        getTimeline('de', params.lang),
+        getTimeline('us', params.lang),
+      ]);
+      allMedia = [...allMediaDe, ...allMediaEn];
+      template = (
+        <StoriesTemplate
+          data={pageData}
+          params={params}
+          subSlugs={subSlugs}
+          baseLink={baseLink}
+          stories={stories}
+          allMedia={allMedia}
+          allPersons={allPersons}
+          topics={topics}
+          timeLineEventsDe={timeLineEventsDe}
+          timeLineEventsEn={timeLineEventsEn}
+        />
+      );
+      break;
+    case 'page_timelines.php':
+      [
+        timeLineEventsDe,
+        timeLineEventsEn,
+        timelineTopics,
+        allMediaDe,
+        allMediaEn,
+        stories,
+        allPersons,
+      ] = await Promise.all([
+        getTimeline('de', params.lang),
+        getTimeline('us', params.lang),
+        getTimelineTopics(params.lang),
+        getAllMedia('de'),
+        getAllMedia('en'),
+        getAllStories(params.lang),
+        getAllPersons(),
+      ]);
+      allMedia = [...allMediaDe, ...allMediaEn];
+      template = (
+        <TimelinesTemplate
+          data={pageData}
+          params={params}
+          subSlugs={subSlugs}
+          baseLink={baseLink}
+          timeLineEventsDe={timeLineEventsDe}
+          timeLineEventsEn={timeLineEventsEn}
+          allMedia={allMedia}
+          timelineTopics={timelineTopics}
+          stories={stories}
+          allPersons={allPersons}
+        />
+      );
+      break;
+    case 'page_about.php':
+      template = <AboutTemplate data={pageData} />;
+      break;
+    case 'page_blog.php':
+      [stories, allPersons] = await Promise.all([
+        getAllStories(params.lang),
+        getAllPersons(),
+      ]);
+      template = (
+        <BlogTemplate
+          data={pageData}
+          params={params}
+          stories={stories}
+          allPersons={allPersons}
+        />
+      );
+      break;
+    case 'page_collaborators.php': {
+      const pages = await getPageListMinimal(params.lang);
+      const partnerPageObj = pages.find((page) => {
+        const urlPageSlug = getUrlPageSlug(page);
+        return urlPageSlug === 'partner' || urlPageSlug === 'partners';
+      });
+      const partnerPageData = partnerPageObj
+        ? await getPage(params.lang, partnerPageObj.id)
+        : null;
+      template = (
+        <>
+          <CollaboratorsTemplate
             data={pageData}
-            params={params}
             subSlugs={subSlugs}
-            baseLink={pageSlug}
-            stories={stories}
-            allMedia={allMedia}
-            allPersons={allPersons}
-            topics={topics}
-            timeLineEventsDe={timeLineEventsDe}
-            timeLineEventsEn={timeLineEventsEn}
+            baseLink={baseLink}
           />
-        );
-        break;
-      case 'page_timelines.php':
-        [
-          timeLineEventsDe,
-          timeLineEventsEn,
-          timelineTopics,
-          allMediaDe,
-          allMediaEn,
-          stories,
-          allPersons,
-        ] = await Promise.all([
-          getTimeline('de', params.lang),
-          getTimeline('us', params.lang),
-          getTimelineTopics(params.lang),
-          getAllMedia('de'),
-          getAllMedia('en'),
-          getAllStories(params.lang),
-          getAllPersons(),
-        ]);
-        allMedia = [...allMediaDe, ...allMediaEn];
-        template = (
-          <TimelinesTemplate
-            data={pageData}
-            params={params}
-            subSlugs={subSlugs}
-            baseLink={pageSlug}
-            timeLineEventsDe={timeLineEventsDe}
-            timeLineEventsEn={timeLineEventsEn}
-            allMedia={allMedia}
-            timelineTopics={timelineTopics}
-            stories={stories}
-            allPersons={allPersons}
-          />
-        );
-        break;
-      case 'page_about.php':
-        template = <AboutTemplate data={pageData} />;
-        break;
-      case 'page_blog.php':
-        [stories, allPersons] = await Promise.all([
-          getAllStories(params.lang),
-          getAllPersons(),
-        ]);
-        template = (
-          <BlogTemplate
-            data={pageData}
-            params={params}
-            stories={stories}
-            allPersons={allPersons}
-          />
-        );
-        break;
-      case 'page_collaborators.php':
-        const partnerPageObj = pages.find((page) => {
-          const url = new URL(page.link);
-          const urlPageSlug = url
-            .toString()
-            .substring(url.origin.length)
-            .replace(/^\/|\/$/g, '')
-            .replace(/^(de\/|en\/|ed\/)/, '');
-          return urlPageSlug === 'partner' || urlPageSlug === 'partners';
-        });
-        const partnerPageData = await getPage(params.lang, partnerPageObj.id);
-        template = (
-          <>
-            <CollaboratorsTemplate
-              data={pageData}
-              subSlugs={subSlugs}
-              baseLink={pageSlug}
-            />
-            <PartnersTemplate data={partnerPageData} />
-          </>
-        );
-        break;
-      case 'page_events.php':
-        template = <EventsTemplate data={pageData} params={params} />;
-        break;
-      case 'page_workshops.php':
-        template = <WorkshopsTemplate data={pageData} />;
-        break;
-      case 'page_takePart.php':
-        template = <TakePartTemplate data={pageData} />;
-        break;
-      case 'page_donate.php':
-        template = <DonateTemplate data={pageData} />;
-        break;
-      case 'page_materials.php':
-        template = <MaterialsTemplate data={pageData} />;
-        break;
-      case 'page_projects.php':
-        template = <ProjectsTemplate data={pageData} />;
-        break;
-      case 'page_home.php':
-        template = (
-          <HomeTemplate data={pageData} params={params} subSlugs={subSlugs} />
-        );
-        break;
-      default:
-        template = <DefaultTemplate data={pageData} />;
-        break;
+          {partnerPageData && <PartnersTemplate data={partnerPageData} />}
+        </>
+      );
+      break;
     }
-  } else {
-    return notFound();
+    case 'page_events.php':
+      template = <EventsTemplate data={pageData} params={params} />;
+      break;
+    case 'page_workshops.php':
+      template = <WorkshopsTemplate data={pageData} />;
+      break;
+    case 'page_takePart.php':
+      template = <TakePartTemplate data={pageData} />;
+      break;
+    case 'page_donate.php':
+      template = <DonateTemplate data={pageData} />;
+      break;
+    case 'page_materials.php':
+      template = <MaterialsTemplate data={pageData} />;
+      break;
+    case 'page_projects.php':
+      template = <ProjectsTemplate data={pageData} />;
+      break;
+    case 'page_home.php': {
+      const pages = await getPageListMinimal(params.lang);
+      template = (
+        <HomeTemplate
+          data={pageData}
+          params={params}
+          subSlugs={subSlugs}
+          pages={pages}
+        />
+      );
+      break;
+    }
+    default:
+      template = <DefaultTemplate data={pageData} />;
+      break;
   }
 
   return (
@@ -260,10 +274,8 @@ export async function generateStaticParams() {
 
       const baseSlugs = urlPageSlug.split('/').filter(Boolean);
 
-      // Add the base page path
       paths.push({ lang, slugs: baseSlugs });
 
-      // Conditionally add paths for stories, timeline events, and posts
       if (page.template === 'page_stories.php') {
         stories.forEach((story) => {
           paths.push({
@@ -306,72 +318,49 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata({ params }) {
-  const pages = await getPageListMinimal(params.lang);
+  const slugs = params.slugs ?? [];
+  const uri = slugs.join('/');
+  const resolved = await resolveUri(uri, params.lang);
+  if (!resolved) return undefined;
 
-  // find page by slugs
-  let pageSlugs = [...(params.slugs ?? [])];
-  let pageSlug = '';
-  let subSlugs = [];
-  let pageObj;
-  let pageData;
-  if (pageSlugs.length > 0) {
-    while (pageSlugs.length > 0) {
-      pageObj = pages.find((page) => {
-        const url = new URL(page.link);
-        const urlPageSlug = url
-          .toString()
-          .substring(url.origin.length)
-          .replace(/^\/|\/$/g, '')
-          .replace(/^(de\/|en\/)/, '');
-        return urlPageSlug === pageSlugs?.join('/');
-      });
-      if (pageObj) {
-        pageSlug = pageObj.link;
-        break;
-      }
-      subSlugs = [...subSlugs, pageSlugs.pop()];
-    }
-    if (!pageObj) {
-      const frontpageId = await getFrontpageId(params.lang);
-      pageObj = pages.find((page) => page.id === parseInt(frontpageId));
-    }
-  } else {
-    const frontpageId = await getFrontpageId(params.lang);
-    pageObj = pages.find((page) => page.id === parseInt(frontpageId));
+  const { id, type } = resolved;
+  let pageId = id;
+  if (type !== 'page') {
+    const baseUri = slugs.slice(0, -1).join('/');
+    const parentResolved = await resolveUri(baseUri, params.lang);
+    if (!parentResolved) return undefined;
+    pageId = parentResolved.id;
   }
 
-  // get page
-  if (pageObj) {
-    pageData = await getPage(params.lang, pageObj.id);
-    const seoData = pageData.seo;
+  const pageData = await getPage(params.lang, pageId);
+  const seoData = pageData?.seo;
 
-    return {
-      metadataBase: process.env.PUBLIC_URL,
-      description: seoData?._genesis_description,
-      openGraph: {
-        title: seoData?._open_graph_title,
-        description: seoData?._open_graph_description,
-        images:
-          seoData?._social_image_url !== ''
-            ? [
-                {
-                  url: `${process.env.NEXT_PUBLIC_CMS_URL}${seoData?._social_image_url}`,
-                },
-              ]
-            : [],
-      },
-      twitter: {
-        title: seoData?._twitter_title,
-        description: seoData?._twitter_description,
-        images:
-          seoData?._social_image_url !== ''
-            ? [
-                `${process.env.NEXT_PUBLIC_CMS_URL}${seoData?._social_image_url}`,
-              ]
-            : [],
-      },
-    };
-  }
+  return {
+    metadataBase: process.env.PUBLIC_URL,
+    description: seoData?._genesis_description,
+    openGraph: {
+      title: seoData?._open_graph_title,
+      description: seoData?._open_graph_description,
+      images:
+        seoData?._social_image_url !== ''
+          ? [
+              {
+                url: `${process.env.NEXT_PUBLIC_CMS_URL}${seoData?._social_image_url}`,
+              },
+            ]
+          : [],
+    },
+    twitter: {
+      title: seoData?._twitter_title,
+      description: seoData?._twitter_description,
+      images:
+        seoData?._social_image_url !== ''
+          ? [
+              `${process.env.NEXT_PUBLIC_CMS_URL}${seoData?._social_image_url}`,
+            ]
+          : [],
+    },
+  };
 }
 
 export default Page;

--- a/components/templates/HomeTemplate.jsx
+++ b/components/templates/HomeTemplate.jsx
@@ -20,14 +20,14 @@ import { getAllPosts } from '@/utilities/posts';
 import EventsList from '@/components/publicEvents/EventsList';
 import FlexibleContent from '@/components/home/flexibleContent';
 
-const HomeTemplate = async ({ data, params, subSlugs }) => {
+const HomeTemplate = async ({ data, params, subSlugs, pages: pagesProp }) => {
   const [stories, allMedia, allPersons, topics] = await Promise.all([
     getAllStories(params.lang),
     getAllMedia(params.lang),
     getAllPersons(),
     fetchAllTopics(params.lang),
   ]);
-  const pages = await getPageListMinimal(params.lang);
+  const pages = pagesProp ?? (await getPageListMinimal(params.lang));
   const events = await getAllPosts(params.lang, 'publicevent');
   const upcomingEvents = [...events]
     .filter((e) => new Date(e.acf?.date_sorting) > new Date())

--- a/utilities/pages.js
+++ b/utilities/pages.js
@@ -1,6 +1,23 @@
 const PAGE_LIST_FIELDS = 'id,link,slug,parent,template';
 
 /**
+ * Resolves URI + lang to database id and type via backend.
+ * @param {string} uri Path without leading slash or lang prefix (e.g. 'about', 'stories/sexual-identity').
+ * @param {string} lang Language code ('en' | 'de').
+ * @returns {Promise<{ id: number, type: string } | null>}
+ */
+export async function resolveUri(uri, lang) {
+  const base = process.env.NEXT_PUBLIC_CMS_URL;
+  const url = `${base}/wp-json/wwarrest/v1/resolve?uri=${encodeURIComponent(uri)}&lang=${encodeURIComponent(lang)}`;
+  const res = await fetch(url, {
+    next: { revalidate: 600 },
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data && typeof data.id === 'number' && data.type ? data : null;
+}
+
+/**
  * Fetches minimal page list (id, link, slug, parent, template) for path
  * resolution and static params. Use getPage(lang, id) for full page data.
  */


### PR DESCRIPTION
## Use resolve endpoint for page resolution

Resolve the current resource (uri + lang) via the backend instead of loading the full minimal page list on every request. Only fetch the page list when rendering the collaborators or home template.

### Before

```mermaid
flowchart LR
  A[getPageSettings] --> B[getPageListMinimal]
  B --> C[Find page by slugs]
  C --> D[getPage]
  D --> E[Template + data]
```

### After

```mermaid
flowchart LR
  A[getPageSettings] --> B[resolveUri]
  B --> C{id, type}
  C --> D[getPage or parent]
  D --> E[Template + data]
  E --> F{Collaborators or Home?}
  F -->|yes| G[getPageListMinimal]
  F -->|no| H[skip]
  G --> I[Render]
  H --> I
```

- **Default:** resolve + getPage (+ template data). No page list.
- **Collaborators / Home:** same as above, then one getPageListMinimal in that branch and pass result into the template.

## Data flow (sub-resources)

```mermaid
flowchart LR
  subgraph resolve [Resolve]
    R1[resolveUri full uri]
    R2[resolveUri base uri]
  end
  R1 --> T{type}
  T -->|page| P1[getPage id]
  T -->|story etc| R2
  R2 --> P2[getPage parent id]
  P1 --> Switch[Template switch]
  P2 --> Switch
```

For `type === 'page'` we use the resolved id. For story/timeline_event/post we resolve the base path to get the parent page id, then getPage(parent) for pageData and template.

## Changes

| Area | Change |
|------|--------|
| **utilities/pages.js** | Add `resolveUri(uri, lang)` → `{ id, type }` or null. |
| **page.jsx** | Replace getPageListMinimal + slug loop with resolveUri; get template from pageData; Option B for collaborators (list only in that branch); Option A for home (fetch list and pass `pages` to HomeTemplate). |
| **generateMetadata** | resolveUri(uri, lang) then getPage(owning page id); build metadata from pageData.seo. |
| **HomeTemplate** | Optional `pages` prop; use it when provided, else call getPageListMinimal. |
| **generateStaticParams** | Unchanged (still needs full path list). |

## Backend

- Uses new `GET /wp-json/wwarrest/v1/resolve?uri=...&lang=...` returning `{ id, type }`.
- Template is read from getPage response (`pageData.template` or `pageData.meta?.template`); 

